### PR TITLE
fix: staticfiles_urlpatterns 추가해서 gunicorn에서 정적 파일 서빙하는 방식 바꾸기 (/swagger URL 살리기)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,6 @@ db.sqlite3
 
 # debug
 .vscode/
+
+# custom
+dbmodels.py

--- a/onestep_be/urls.py
+++ b/onestep_be/urls.py
@@ -3,6 +3,7 @@ from django.urls import include, path
 from drf_yasg import openapi
 from drf_yasg.views import get_schema_view
 from rest_framework.permissions import AllowAny
+from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 
 schema_view = get_schema_view(
     openapi.Info(
@@ -34,3 +35,5 @@ urlpatterns = [
     path("todos/", include("todos.urls")),
     path("feedback/", include("feedback.urls")),
 ]
+
+urlpatterns += staticfiles_urlpatterns()


### PR DESCRIPTION
## What is this PR? 🔎

- **Jira Ticket**:[SZ-339](https://swm-safezone.atlassian.net/browse/SZ-339)

  <br/>

## Changes 📝

한 줄 소개
- gunicorn에서 정적 파일 서빙이 안 되어서 swagger 뷰가 나타나지 않는다고 가정하고, 관련 코드를 바꿔보았습니다. 
  </br>


[SZ-339]: https://swm-safezone.atlassian.net/browse/SZ-339?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ